### PR TITLE
Update state contract to 0xb1983E8ce013F62fC503AA5C7704B91a3bf25eC8

### DIFF
--- a/snapshotter_autofill.sh
+++ b/snapshotter_autofill.sh
@@ -52,7 +52,7 @@ export ipfs_url="${IPFS_URL:-/dns/ipfs/tcp/5001}"
 export ipfs_api_key="${IPFS_API_KEY:-}"
 export ipfs_api_secret="${IPFS_API_SECRET:-}"
 
-export protocol_state_contract="${PROTOCOL_STATE_CONTRACT:-0xb71EAc336ffd776BAe4b1F861E58FaF13aB7c34B}"
+export protocol_state_contract="${PROTOCOL_STATE_CONTRACT:-0xb1983E8ce013F62fC503AA5C7704B91a3bf25eC8}"
 export slack_reporting_url="${SLACK_REPORTING_URL:-}"
 export powerloom_reporting_url="${POWERLOOM_REPORTING_URL:-}"
 


### PR DESCRIPTION
Still on the older contract when `build.sh` auto fills leading to errors.