### PR TITLE
Increase public rate limit for pooler API

### DIFF
--- a/config/settings.example.json
+++ b/config/settings.example.json
@@ -7,7 +7,7 @@
       "enabled": false,
       "header_key": "X-API-KEY"
     },
-    "public_rate_limit": "10000/day;200/minute;5/second"
+    "public_rate_limit": "20000/day;300/minute;10/second"
   },
   "instance_id": "account-address",
   "rpc": {


### PR DESCRIPTION
### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.

### Current behaviour
On fast connections, we easily hit rate limits on the internal API used by pooler frontend.

### New expected behaviour
Doubles the `per second` rate limit allowing calls to go through on first load