### PR TITLE
fix: fetch last finalized epoch ID for project from protocol state contract

### DIFF
--- a/pooler/core_api.py
+++ b/pooler/core_api.py
@@ -226,6 +226,10 @@ async def get_project_last_finalized_epoch_info(
                 if epoch_finalized_contract[0]:
                     epoch_finalized = True
                     project_last_finalized_epoch = epoch_id
+                    await request.app.state.redis_pool.set(
+                        project_last_finalized_epoch_key(project_id),
+                        project_last_finalized_epoch,
+                    )
                 else:
                     epoch_id -= 1
                     if epoch_id < 0:


### PR DESCRIPTION
Fixes #37 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->

During a fresh run of a node, before the local services receive their first snapshot finalization event for a project, the same project's query for last finalized epoch ID on `core_api.py` would fail.

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
This fix ensure even if a loally cached state is not available for project's finalized epoch ID, `core_api` can consult last finalized status from the protocol state contract.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


#### Fixed 
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->

Request handler:

https://github.com/PowerLoom/pooler/blob/03302099be391f4637d7a22b9eab45473c4758e4/pooler/core_api.py#L186

Fetch from protocol state contract:

https://github.com/PowerLoom/pooler/blob/03302099be391f4637d7a22b9eab45473c4758e4/pooler/core_api.py#L212-L238

<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
Restart [`gunicorn_core_launcher.py`](https://github.com/PowerLoom/pooler/blob/37-last-finalized-epoch-id-from-protocol-state/pooler/gunicorn_core_launcher.py)
