### PR TITLE
uniswapv3 tvl and tick data update

### DIFF
--- a/pooler/modules/uniswapv3/redis_keys.py
+++ b/pooler/modules/uniswapv3/redis_keys.py
@@ -54,3 +54,7 @@ uniswap_token_derived_eth_cached_block_height = (
 uniswap_cached_block_height_token_eth_price = (
     "uniswap:pairContract:" + settings.namespace + ":{}:cachedBlockHeightTokenEthPrice"
 )
+
+uniswap_cached_tick_data_block_height = (
+    "uniswap:pairContract:" + settings.namespace + ":{}:cachedBlockHeightTickData"
+)

--- a/pooler/tests/test_tvl.py
+++ b/pooler/tests/test_tvl.py
@@ -14,9 +14,9 @@ from pooler.utils.rpc import RpcHelper
 async def test_calculate_reserves():
     # Mock your parameters
     pair_address = Web3.to_checksum_address(
-        "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640"
+        "0x7858E59e0C01EA06Df3aF3D20aC7B0003275D4Bf"
     )
-    from_block = 18472036
+    from_block = 18746454
     rpc_helper = RpcHelper()
     aioredis_pool = RedisPoolCache()
 
@@ -50,6 +50,9 @@ async def test_calculate_reserves():
     # The function name 'getReserves' and the field names may differ based on the actual ABI
     token0_actual_reserve = token0_contract.functions.balanceOf(pair_address).call()
     token1_actual_reserve = token1_contract.functions.balanceOf(pair_address).call()
+
+    print(reserves)
+    print(token0_actual_reserve, token1_actual_reserve)
 
     # Compare them with returned reserves
     # our calculations should be less than or equal to token balance.

--- a/pooler/utils/rpc.py
+++ b/pooler/utils/rpc.py
@@ -520,7 +520,7 @@ class RpcHelper(object):
                             "data": function_signature,
                         },
                         hex(block),
-                        overrides,
+                        overrides if overrides is not None else {},
                     ],
                     "id": request_id,
                 },


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR --> uniswapv3 tvl and tick data corrections
<!-- Add issue number (Eg: fixes #123) -->  #56
<!-- Always provide changes in existing tests or new tests -->


Fixes #

Fixes uniswapv3 liquidity pool total value locked calculation.
Fixes bug with batch_eth_call_on_block_range() in pooler.utils.rpc when using state overrides

### Checklist
- [ ] My branch is up-to-date with upstream/develop branch.
- [ x] Everything works and tested for Python 3.8.0 and above.
- [ ] I ran pre-commit checks against my changes.
- [ x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
pooler.modules.uniswapv3.total_value_locked's caclulate_reserves() function is currently incorrectly calculating duplicate ticks as well as failing to process some retrieved ticks.

caclulate_reserves() does not cache the results from the very expensive getTicks() call that it makes.

### New expected behaviour
The calcuate_reserves() function will process each tick only once, and will process all of the ticks in the pool to produce a more accurate total value locked calculation.

calculate_reserves() will cache tick data using redis to eliminate the need for duplicate calls by multiple processes.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 --> redis caching of tick data

<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 --> pooler.modules.uniswapv3.total_value_locked.calculate_reserves()

<!-- - Change 1 --> 


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 --> pooler.utils.rpc.batch_eth_call_on_block_range()



<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
