### PR TITLE
update rpc helper to support block and state override

### DIFF
--- a/snapshotter/utils/rpc.py
+++ b/snapshotter/utils/rpc.py
@@ -344,18 +344,9 @@ class RpcHelper(object):
                 return current_block
         return await f(node_idx=0)
 
-    async def _async_web3_call(self, contract_function, redis_conn, from_address=None):
-        """
-        Executes a web3 call asynchronously.
+    async def _async_web3_call(self, contract_function, redis_conn, from_address=None, block=None, overrides=None):
+        """Make async web3 call"""
 
-        Args:
-            contract_function: The contract function to call.
-            redis_conn: The Redis connection object.
-            from_address: The address to send the transaction from.
-
-        Returns:
-            The result of the web3 call.
-        """
         @retry(
             reraise=True,
             retry=retry_if_exception_type(RPCException),
@@ -365,43 +356,42 @@ class RpcHelper(object):
         )
         async def f(node_idx):
             try:
-
                 node = self._nodes[node_idx]
-                rpc_url = node.get('rpc_url')
+                rpc_url = node.get("rpc_url")
 
                 await check_rpc_rate_limit(
-                    parsed_limits=node.get('rate_limit', []),
-                    app_id=rpc_url.split('/')[-1],
+                    parsed_limits=node.get("rate_limit", []),
+                    app_id=rpc_url.split("/")[-1],
                     redis_conn=redis_conn,
                     request_payload=contract_function.fn_name,
                     error_msg={
-                        'msg': 'exhausted_api_key_rate_limit inside web3_call',
+                        "msg": "exhausted_api_key_rate_limit inside web3_call",
                     },
                     logger=self._logger,
                     rate_limit_lua_script_shas=self._rate_limit_lua_script_shas,
                     limit_incr_by=1,
                 )
-
-                params: TxParams = {'gas': Wei(0), 'gasPrice': Wei(0)}
+                # NOTE is there a reason this is set to 0? 
+                params: TxParams = {"gas": Wei(0), "gasPrice": Wei(0)}
 
                 if not contract_function.address:
                     raise ValueError(
-                        f'Missing address for batch_call in `{contract_function.fn_name}`',
+                        f"Missing address for batch_call in `{[contract_function.fn_name]}`",
                     )
 
                 output_type = [
-                    output['type'] for output in contract_function.abi['outputs']
+                    output["type"] for output in contract_function.abi["outputs"]
                 ]
                 payload = {
-                    'to': contract_function.address,
-                    'data': contract_function.build_transaction(params)['data'],
-                    'output_type': output_type,
-                    'fn_name': contract_function.fn_name,  # For debugging purposes
+                    "to": contract_function.address,
+                    "data": contract_function.build_transaction(params)["data"],
+                    "output_type": output_type,
+                    "fn_name": contract_function.fn_name,  # For debugging purposes
                 }
 
                 cur_time = time.time()
                 redis_cache_data = payload.copy()
-                redis_cache_data['time'] = cur_time
+                redis_cache_data["time"] = cur_time
                 await asyncio.gather(
                     redis_conn.zadd(
                         name=rpc_web3_calls,
@@ -417,16 +407,26 @@ class RpcHelper(object):
                 )
 
                 if from_address:
-                    payload['from'] = from_address
+                    payload["from"] = from_address
 
-                data = await node['web3_client_async'].eth.call(payload)
+                data = await node["web3_client_async"].eth.call(
+                    payload, block_identifier=block, state_override=overrides
+                    )
+                
+                # if we're doing a state override call, at time of writing it means grabbing tick data
+                # more efficient to use eth_abi to decode rather than web3 codec
+                if overrides is not None:
+                    return data
 
-                decoded_data = node['web3_client_async'].codec.decode_abi(
-                    output_type, HexBytes(data),
+                decoded_data = node["web3_client_async"].codec.decode(
+                    output_type,
+                    HexBytes(data),
                 )
 
                 normalized_data = map_abi_data(
-                    BASE_RETURN_NORMALIZERS, output_type, decoded_data,
+                    BASE_RETURN_NORMALIZERS,
+                    output_type,
+                    decoded_data,
                 )
 
                 if len(normalized_data) == 1:
@@ -438,17 +438,17 @@ class RpcHelper(object):
                     request=[contract_function.fn_name],
                     response=None,
                     underlying_exception=e,
-                    extra_info={'msg': str(e)},
+                    extra_info={"msg": str(e)},
                 )
-                self._logger.opt(exception=settings.logs.trace_enabled).error(
-                    (
-                        'Error while making web3 batch call'
-                    ),
+
+                self._logger.opt(lazy=True).trace(
+                    ("Error while making web3 batch call"),
                     err=lambda: str(exc),
                 )
                 raise exc
 
         return await f(node_idx=0)
+
 
     async def get_transaction_receipt(self, tx_hash, redis_conn):
         """
@@ -577,7 +577,7 @@ class RpcHelper(object):
         )
         return current_block
 
-    async def web3_call(self, tasks, redis_conn, from_address=None):
+    async def web3_call(self, tasks, redis_conn, from_address=None, block=None, overrides=None):
         """
         Calls the given tasks asynchronously using web3 and returns the response.
 
@@ -589,19 +589,27 @@ class RpcHelper(object):
         Returns:
             list: List of responses from the contract function calls.
         """
+
         if not self._initialized:
             await self.init(redis_conn)
 
         try:
             web3_tasks = [
                 self._async_web3_call(
-                    contract_function=task, redis_conn=redis_conn, from_address=from_address,
-                ) for task in tasks
+                    contract_function=task,
+                    redis_conn=redis_conn,
+                    from_address=from_address,
+                    block=block,
+                    overrides=overrides
+                
+                )
+                for task in tasks
             ]
             response = await asyncio.gather(*web3_tasks)
             return response
         except Exception as e:
             raise e
+
 
     async def _make_rpc_jsonrpc_call(self, rpc_query, redis_conn):
         """

--- a/snapshotter/utils/rpc.py
+++ b/snapshotter/utils/rpc.py
@@ -345,7 +345,17 @@ class RpcHelper(object):
         return await f(node_idx=0)
 
     async def _async_web3_call(self, contract_function, redis_conn, from_address=None, block=None, overrides=None):
-        """Make async web3 call"""
+
+        """
+        Executes a web3 call asynchronously.
+        Args:
+            contract_function: The contract function to call.
+            redis_conn: The Redis connection object.
+            from_address: The address to send the transaction from.
+
+        Returns:
+            The result of the web3 call.
+        """
 
         @retry(
             reraise=True,


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
fixes https://github.com/PowerLoom/pooler/issues/58
<!-- Always provide changes in existing tests or new tests -->

Fixes #

### Checklist
- [x ] My branch is up-to-date with upstream/develop branch.
- [ x] Everything works and tested for Python 3.8.0 and above.
- [ ] I ran pre-commit checks against my changes.
- [ x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
The current rpc helper doesnt support state override calls or rpc calls relating to specific block height. this PR addresses both. 
### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
This code allows state override calls at specific block heights to be made. 

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
Added support for state overrride calls
<!-- - Feature 2 -->
added support for rpc calls to specific block height. 



