### PR TITLE
fix: rpc polling in system_event_detector

### DIFF
--- a/snapshotter/system_event_detector.py
+++ b/snapshotter/system_event_detector.py
@@ -305,9 +305,9 @@ class EventDetectorProcess(multiprocessing.Process):
             if self._last_processed_block == current_block:
                 self._logger.info(
                     'No new blocks detected, sleeping for {} seconds...',
-                    settings.anchor_chain.polling_interval,
+                    settings.rpc.polling_interval,
                 )
-                await asyncio.sleep(settings.anchor_chain.polling_interval)
+                await asyncio.sleep(settings.rpc.polling_interval)
                 continue
 
             if self._last_processed_block:


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) --> issue #69
<!-- Always provide changes in existing tests or new tests -->

Fixes #

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
System event detector can crash under certain conditions by trying to find a settings variable that doesn't exist.

### New expected behaviour
System event detector will sleep for the polling interval when `last_processed_block` equals `current_block` for the anchor chain.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->

<!-- - Change 1 -->


#### Fixed
<!-- Edit these points below to describe the bug fixes made with this PR -->
- `settings.anchor_chain.polling_interval` with `settings.rpc.polling_interval` in system_event_detector._detect_events


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
