### PR TITLE
Fix/snapshotter overall status

### DIFF
--- a/snapshotter/processor_distributor.py
+++ b/snapshotter/processor_distributor.py
@@ -334,7 +334,7 @@ class ProcessorDistributor(multiprocessing.Process):
                             data_source,
                         )
                     project_config.projects = list(project_data)
-                all_projects += [f'{project_type}:{project}:{settings.namespace}' for project in project_config.projects]
+                all_projects += [f'{project_type}:{project.lower()}:{settings.namespace}' for project in project_config.projects]
 
             for config in aggregator_config:
                 if config.aggregate_on == AggregateOn.single_project:

--- a/snapshotter/processor_distributor.py
+++ b/snapshotter/processor_distributor.py
@@ -45,6 +45,8 @@ from snapshotter.utils.data_utils import get_source_chain_epoch_size
 from snapshotter.utils.data_utils import get_source_chain_id
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.file_utils import read_json_file
+from snapshotter.utils.helper_functions import gen_multiple_type_project_id
+from snapshotter.utils.helper_functions import gen_single_type_project_id
 from snapshotter.utils.models.data_models import SnapshotterEpochProcessingReportItem
 from snapshotter.utils.models.data_models import SnapshotterIssue
 from snapshotter.utils.models.data_models import SnapshotterReportState
@@ -70,6 +72,7 @@ from snapshotter.utils.redis.redis_keys import process_hub_core_start_timestamp
 from snapshotter.utils.redis.redis_keys import project_finalized_data_zset
 from snapshotter.utils.redis.redis_keys import project_last_finalized_epoch_key
 from snapshotter.utils.redis.redis_keys import snapshot_submission_window_key
+from snapshotter.utils.redis.redis_keys import stored_projects_key
 from snapshotter.utils.rpc import RpcHelper
 # from snapshotter.utils.data_utils import build_projects_list_from_events
 
@@ -318,6 +321,7 @@ class ProcessorDistributor(multiprocessing.Process):
 
             # self._logger.info('Generated project list with {} projects', self._projects_list)
 
+            all_projects = []
             # iterate over project list fetched
             for project_type, project_config in self._project_type_config_mapping.items():
                 project_type = project_config.project_type
@@ -330,6 +334,23 @@ class ProcessorDistributor(multiprocessing.Process):
                             data_source,
                         )
                     project_config.projects = list(project_data)
+                all_projects += [f'{project_type}:{project}:{settings.namespace}' for project in project_config.projects]
+
+            for config in aggregator_config:
+                if config.aggregate_on == AggregateOn.single_project:
+                    project_ids = filter(lambda x: config.filters.projectId in x, all_projects)
+                    all_projects += [
+                        gen_single_type_project_id(config.project_type, project_id)
+                        for project_id in project_ids
+                    ]
+                if config.aggregate_on == AggregateOn.multi_project:
+                    all_projects.append(gen_multiple_type_project_id(config.project_type, config.projects_to_wait_for))
+
+            # update stored project set in redis
+            await self._redis_conn.sadd(
+                stored_projects_key(),
+                *all_projects,
+            )
 
             submission_window = await get_snapshot_submision_window(
                 redis_conn=self._redis_conn,

--- a/snapshotter/utils/data_utils.py
+++ b/snapshotter/utils/data_utils.py
@@ -28,6 +28,7 @@ from snapshotter.utils.redis.redis_keys import project_snapshotter_status_report
 from snapshotter.utils.redis.redis_keys import source_chain_block_time_key
 from snapshotter.utils.redis.redis_keys import source_chain_epoch_size_key
 from snapshotter.utils.redis.redis_keys import source_chain_id_key
+from snapshotter.utils.redis.redis_keys import stored_projects_key
 from snapshotter.utils.rpc import get_event_sig_and_abi
 
 logger = logger.bind(module='data_helper')
@@ -626,7 +627,7 @@ async def get_snapshotter_status(redis_conn: aioredis.Redis):
     """
     status_keys = []
 
-    all_projects = await redis_conn.smembers('storedProjectIds')
+    all_projects = await redis_conn.smembers(stored_projects_key())
     all_projects = [project_id.decode('utf-8') for project_id in all_projects]
 
     for project_id in all_projects:

--- a/snapshotter/utils/helper_functions.py
+++ b/snapshotter/utils/helper_functions.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import sys
 from functools import wraps
 
@@ -177,3 +178,38 @@ def _parse_value(val):
         return val.hex()
     else:
         return val
+
+
+def gen_single_type_project_id(task_type, project_id):
+    """
+    Generates a project ID for a single task type and epoch.
+
+    Args:
+        task_type (str): The task type.
+        epoch (Epoch): The epoch object.
+
+    Returns:
+        str: The generated project ID.
+    """
+    data_source = project_id.split(':')[-2]
+    project_id = f'{task_type}:{data_source}:{settings.namespace}'
+    return project_id
+
+
+def gen_multiple_type_project_id(task_type, underlying_project_ids):
+    """
+    Generates a unique project ID based on the task type and epoch messages.
+
+    Args:
+        task_type (str): The type of task.
+        epoch (Epoch): The epoch object containing messages.
+
+    Returns:
+        str: The generated project ID.
+    """
+    unique_project_id = ''.join(sorted(underlying_project_ids))
+
+    project_hash = hashlib.sha3_256(unique_project_id.encode()).hexdigest()
+
+    project_id = f'{task_type}:{project_hash}:{settings.namespace}'
+    return project_id


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->#71
<!-- Always provide changes in existing tests or new tests -->

Fixes #

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The `/internal/snapshotter/status` endpoint returns an empty status report regardless of the projects running on the node.

### New expected behaviour
`/internal/snapshotter/status` returns a complete report of correct, incorrect, and missed snapshots for all known projects.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed

- `_load_projects_metadata()` in `process_distributor.py` now builds a list of all projects based on the provided config and caches it to redis for retrieval in `data_utils.get_snapshotter_status()`. 
- Moved the project_id gen functions from inside the `AggregationAsyncWorker` class to `helper_functions.py`.


#### Fixed
- Changed hard coded redis key to the getter in `data_utils.get_snapshotter_status()`
