### PR TITLE
chore: fix redis param name in GenericProcessorSnapshot

### DIFF
--- a/snapshotter/utils/callback_helpers.py
+++ b/snapshotter/utils/callback_helpers.py
@@ -190,7 +190,7 @@ class GenericProcessorSnapshot(ABC):
     async def compute(
         self,
         epoch: PowerloomSnapshotProcessMessage,
-        redis: aioredis.Redis,
+        redis_conn: aioredis.Redis,
         rpc_helper: RpcHelper,
     ):
         pass


### PR DESCRIPTION

Fixes #85

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.


### Changes

Update `GenericProcessorSnapshot` definition to 

```python
    @abstractmethod
    async def compute(
        self,
        epoch: PowerloomSnapshotProcessMessage,
        redis_conn: aioredis.Redis,
        rpc_helper: RpcHelper,
    ):
        pass
```