### PR TITLE
Feat/devnet snapshotter id check

### DIFF
--- a/snapshotter/snapshotter_id_ping.py
+++ b/snapshotter/snapshotter_id_ping.py
@@ -7,8 +7,8 @@ from web3 import Web3
 from snapshotter.auth.helpers.redis_conn import RedisPoolCache
 from snapshotter.settings.config import settings
 from snapshotter.utils.file_utils import read_json_file
-from snapshotter.utils.rpc import RpcHelper
 from snapshotter.utils.redis.redis_keys import active_status_key
+from snapshotter.utils.rpc import RpcHelper
 
 
 async def main():

--- a/snapshotter/snapshotter_id_ping.py
+++ b/snapshotter/snapshotter_id_ping.py
@@ -20,7 +20,46 @@ async def main():
     aioredis_pool = RedisPoolCache(pool_size=1000)
     await aioredis_pool.populate()
     redis_conn = aioredis_pool._aioredis_pool
-    
+
+    anchor_rpc = RpcHelper(settings.anchor_chain_rpc)
+    await anchor_rpc.init(redis_conn=redis_conn)
+    protocol_abi = read_json_file(settings.protocol_state.abi)
+    protocol_state_contract = anchor_rpc.get_current_node()['web3_client'].eth.contract(
+        address=Web3.toChecksumAddress(
+            settings.protocol_state.address,
+        ),
+        abi=protocol_abi,
+    )
+
+    snapshotter_address = to_checksum_address(settings.instance_id)
+
+    snapshotters_arr_query = await anchor_rpc.web3_call(
+        [
+            protocol_state_contract.functions.allSnapshotters(snapshotter_address),
+            protocol_state_contract.functions.slotSnapshotterMapping(settings.slot_id),
+        ],
+        redis_conn,
+    )
+
+    snapshotting_allowed = snapshotters_arr_query[0]
+    slot_id_address = snapshotters_arr_query[1]
+
+    if not snapshotting_allowed:
+        print('SIGNER_ACCOUNT_ADDRESS has not been assigned as a snapshotter. Exiting...')
+        await redis_conn.set(
+            active_status_key,
+            int(False),
+        )
+        sys.exit(1)
+    if to_checksum_address(slot_id_address) != to_checksum_address(settings.instance_id):
+        print('SIGNER_ACCOUNT_ADDRESS is not the one configured in SLOT_ID. Exiting...')
+        await redis_conn.set(
+            active_status_key,
+            int(False),
+        )
+        sys.exit(1)
+
+    print('Snapshotting allowed...')
     await redis_conn.set(
         active_status_key,
         int(True),

--- a/snapshotter/snapshotter_id_ping.py
+++ b/snapshotter/snapshotter_id_ping.py
@@ -17,54 +17,58 @@ async def main():
     If snapshotting is allowed, sets the active status key in Redis to True and exits with code 0.
     If snapshotting is not allowed, sets the active status key in Redis to False and exits with code 1.
     """
-    aioredis_pool = RedisPoolCache(pool_size=1000)
-    await aioredis_pool.populate()
-    redis_conn = aioredis_pool._aioredis_pool
+    try:
+        aioredis_pool = RedisPoolCache(pool_size=1000)
+        await aioredis_pool.populate()
+        redis_conn = aioredis_pool._aioredis_pool
 
-    anchor_rpc = RpcHelper(settings.anchor_chain_rpc)
-    await anchor_rpc.init(redis_conn=redis_conn)
-    protocol_abi = read_json_file(settings.protocol_state.abi)
-    protocol_state_contract = anchor_rpc.get_current_node()['web3_client'].eth.contract(
-        address=Web3.toChecksumAddress(
-            settings.protocol_state.address,
-        ),
-        abi=protocol_abi,
-    )
+        anchor_rpc = RpcHelper(settings.anchor_chain_rpc)
+        await anchor_rpc.init(redis_conn=redis_conn)
+        protocol_abi = read_json_file(settings.protocol_state.abi)
+        protocol_state_contract = anchor_rpc.get_current_node()['web3_client'].eth.contract(
+            address=Web3.toChecksumAddress(
+                settings.protocol_state.address,
+            ),
+            abi=protocol_abi,
+        )
 
-    snapshotter_address = to_checksum_address(settings.instance_id)
+        snapshotter_address = to_checksum_address(settings.instance_id)
 
-    snapshotters_arr_query = await anchor_rpc.web3_call(
-        [
-            protocol_state_contract.functions.allSnapshotters(snapshotter_address),
-            protocol_state_contract.functions.slotSnapshotterMapping(settings.slot_id),
-        ],
-        redis_conn,
-    )
+        snapshotters_arr_query = await anchor_rpc.web3_call(
+            [
+                protocol_state_contract.functions.allSnapshotters(snapshotter_address),
+                protocol_state_contract.functions.slotSnapshotterMapping(settings.slot_id),
+            ],
+            redis_conn,
+        )
 
-    snapshotting_allowed = snapshotters_arr_query[0]
-    slot_id_address = snapshotters_arr_query[1]
+        snapshotting_allowed = snapshotters_arr_query[0]
+        slot_id_address = snapshotters_arr_query[1]
 
-    if not snapshotting_allowed:
-        print('SIGNER_ACCOUNT_ADDRESS has not been assigned as a snapshotter. Exiting...')
+        if not snapshotting_allowed:
+            print('SIGNER_ACCOUNT_ADDRESS has not been assigned as a snapshotter. Exiting...')
+            await redis_conn.set(
+                active_status_key,
+                int(False),
+            )
+            sys.exit(1)
+        if to_checksum_address(slot_id_address) != to_checksum_address(settings.instance_id):
+            print('SIGNER_ACCOUNT_ADDRESS is not the one configured in SLOT_ID. Exiting...')
+            await redis_conn.set(
+                active_status_key,
+                int(False),
+            )
+            sys.exit(1)
+
+        print('Snapshotting allowed...')
         await redis_conn.set(
             active_status_key,
-            int(False),
+            int(True),
         )
+        sys.exit(0)
+    except Exception as e:
+        print(f'Error when checking snapshotter identity: {e}. Exiting...')
         sys.exit(1)
-    if to_checksum_address(slot_id_address) != to_checksum_address(settings.instance_id):
-        print('SIGNER_ACCOUNT_ADDRESS is not the one configured in SLOT_ID. Exiting...')
-        await redis_conn.set(
-            active_status_key,
-            int(False),
-        )
-        sys.exit(1)
-
-    print('Snapshotting allowed...')
-    await redis_conn.set(
-        active_status_key,
-        int(True),
-    )
-    sys.exit(0)
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/snapshotter/snapshotter_id_ping.py
+++ b/snapshotter/snapshotter_id_ping.py
@@ -32,28 +32,21 @@ async def main():
             abi=protocol_abi,
         )
 
-        snapshotter_address = to_checksum_address(settings.instance_id)
-
         snapshotters_arr_query = await anchor_rpc.web3_call(
             [
-                protocol_state_contract.functions.allSnapshotters(snapshotter_address),
                 protocol_state_contract.functions.slotSnapshotterMapping(settings.slot_id),
             ],
             redis_conn,
         )
 
-        snapshotting_allowed = snapshotters_arr_query[0]
-        slot_id_address = snapshotters_arr_query[1]
+        slot_id_address = snapshotters_arr_query[0]
 
-        if not snapshotting_allowed:
-            print('SIGNER_ACCOUNT_ADDRESS has not been assigned as a snapshotter. Exiting...')
-            await redis_conn.set(
-                active_status_key,
-                int(False),
-            )
-            sys.exit(1)
         if to_checksum_address(slot_id_address) != to_checksum_address(settings.instance_id):
-            print('SIGNER_ACCOUNT_ADDRESS is not the one configured in SLOT_ID. Exiting...')
+            print(
+                'SIGNER_ACCOUNT_ADDRESS is not the one configured in SLOT_ID.\n'
+                'Ensure that the slot has been assigned and the configured values are correct.\n'
+                'Exiting...',
+            )
             await redis_conn.set(
                 active_status_key,
                 int(False),


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes # https://github.com/PowerLoom/pooler/issues/90

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The snapshotter id ping script currently does not check if the configured signer address is allowed as a snapshotter or if it is the address that has been assigned to the configued slot id.

### New expected behaviour
`snapshotter_id_ping.py` will query the set protocol state contract and check if the configured signer address is correctly assigned as a snapshotter. If not, it will print an exit message and exit the program.

### Change logs

#### Fixed
- `snapshotter/snapshotter_id_ping.py`


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
The script can be tested by running the node with the current instructions. Provide an incorred slot_id or signer address in order to check for proper termination.
